### PR TITLE
Added bff-service and deployed to Elastic Beanstalk

### DIFF
--- a/bff-service/.env
+++ b/bff-service/.env
@@ -1,0 +1,3 @@
+CART=http://maksym-lebedynets-cart-api-develop.eu-west-1.elasticbeanstalk.com/api/profile/cart
+IMPORT=https://12zclhaphd.execute-api.eu-west-1.amazonaws.com/dev/import
+PRODUCT=https://yp0ekii2cc.execute-api.eu-west-1.amazonaws.com/dev/products

--- a/bff-service/.gitignore
+++ b/bff-service/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/bff-service/app.js
+++ b/bff-service/app.js
@@ -1,0 +1,67 @@
+import express from 'express';
+import cors from 'cors';
+import axios from 'axios';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const app = express();
+const port = process.env.PORT || 4000;
+export const headers = {
+  'Access-Control-Allow-Origin': '*', // Required for CORS support to work
+  'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
+};
+
+app.use(cors());
+app.use(express.json());
+
+let cache = {};
+
+setInterval(() => {
+  cache = {};
+}, 10000);
+
+app.all('*', async (req, res) => {
+  const url = req.originalUrl;
+  const serviceName = url.split('/')[1].toUpperCase();
+  const serviceURL = process.env[serviceName];
+  const cacheKey = req.method + '/' + serviceURL;
+
+  console.log('resource: ' + serviceName);
+  console.log('resource url: ' + serviceURL);
+  console.log('___');
+
+  if (serviceURL) {
+    if (cache[cacheKey]) {
+      res.send(cache[cacheKey]);
+
+      return;
+    }
+
+    try {
+      const isBodyExist = Object.keys(req.body || {}).length > 0;
+      const requestConfig = {
+        method: req.method,
+        url: serviceURL,
+      };
+
+      if (isBodyExist) {
+        requestConfig.data = req.body;
+      }
+
+      const response = await axios(requestConfig);
+
+      cache[cacheKey] = response.data;
+
+      res.send(response.data);
+    } catch(error) {
+      res.status(error.status).send(error.data);
+    }
+  } else {
+    res.status(502).send('Cannot process request!');
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Application is on ${port} port`);
+});

--- a/bff-service/package.json
+++ b/bff-service/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "bff-service",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "type": "module",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^0.21.0",
+    "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
+    "express": "^4.17.1"
+  }
+}


### PR DESCRIPTION
PR to FE repository:
https://github.com/maksym-lebedynets/aws-nodejs-program/pull/6

Link to FE application:
http://d2o1n28rymxg96.cloudfront.net/

Evaluation criteria (each mark includes previous mark criteria)

- [x] 3 - A working and correct express application should be in the bff-service folder.
- [x] 5 - The bff-service should be deployed with Elastic Beanstalk. The bff-service call should be redirected to the appropriate service. The response from the bff-service should be the same as if the recipient service was called directly.
- [x] +1 - Add a cache at the bff-service level for a request to the getProductsList function of the product-service. The cache should expire in 2 minutes.
